### PR TITLE
Create compose files.

### DIFF
--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -1,0 +1,12 @@
+---
+name: portainer-agent
+services:
+  portainer-agent:
+    image: docker.io/portainer/agent:2.27.1-alpine
+    container_name: portainer-agent
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+    ports:
+      - '0.0.0.0:9001:9001'
+    restart: unless-stopped

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -1,0 +1,13 @@
+---
+name: portainer
+include:
+  - portainer-agent/docker-compose.yaml
+services:
+  portainer:
+    image: portainer/portainer-ee:2.27.1-alpine
+    container_name: portainer
+    volumes:
+      - /home/herb/portainer/data:/data
+    ports:
+      - '0.0.0.0:9443:9443'
+    restart: unless-stopped


### PR DESCRIPTION
This pull request includes the addition of Docker Compose configurations for the `portainer` and `portainer-agent` services. These changes aim to set up and manage the Portainer environment using Docker Compose.

Docker Compose configurations:

* [`portainer-agent/docker-compose.yaml`](diffhunk://#diff-03ab61cfcf035604728aba5b6a049dc3b5df1e5a4841bc9f6bbeb7ac44506acbR1-R12): Added a configuration file for the `portainer-agent` service, specifying the image, container name, volumes, ports, and restart policy.
* [`portainer/docker-compose.yaml`](diffhunk://#diff-866536e81f316af5a84ba5fd1001a4566a27d89636f7f4323036ec6cccfdd4ebR1-R13): Added a configuration file for the `portainer` service, including the `portainer-agent` configuration, and specifying the image, container name, volume, ports, and restart policy.