### PR TITLE
Update portainer/docker-compose.yaml

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     image: portainer/portainer-ee:2.27.2-alpine
     container_name: portainer
     volumes:
-      - /home/herb/portainer/data:/data
+      - ./data:/data
     ports:
       - '0.0.0.0:9443:9443'
     restart: unless-stopped


### PR DESCRIPTION
This pull request includes a small change to the `portainer/docker-compose.yaml` file. The change modifies the volume mapping for the Portainer service to use a relative path instead of an absolute path.

* [`portainer/docker-compose.yaml`](diffhunk://#diff-866536e81f316af5a84ba5fd1001a4566a27d89636f7f4323036ec6cccfdd4ebL10-R10): Changed the volume mapping from `/home/herb/portainer/data:/data` to `./data:/data`.Change the data path