### PR TITLE
Fix pathing issues.

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -1,13 +1,13 @@
 ---
 name: portainer
 include:
-  - portainer-agent/docker-compose.yaml
+  - ../portainer-agent/docker-compose.yaml
 services:
   portainer:
     image: portainer/portainer-ee:2.27.2-alpine
     container_name: portainer
     volumes:
-      - ./data:/data
+      - ../data:/data
     ports:
       - '0.0.0.0:9443:9443'
     restart: unless-stopped


### PR DESCRIPTION
This pull request includes a small but important change to the `portainer/docker-compose.yaml` file. The change updates the paths for the included `docker-compose.yaml` file and the data volume to use relative paths.

* [`portainer/docker-compose.yaml`](diffhunk://#diff-866536e81f316af5a84ba5fd1001a4566a27d89636f7f4323036ec6cccfdd4ebL4-R10): Changed the path for the included `docker-compose.yaml` file to `../portainer-agent/docker-compose.yaml` and updated the data volume path to `../data:/data`.