### PR TITLE
Create dclint.yml

### DIFF
--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -1,0 +1,18 @@
+name: Docker Compose Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  dclint:
+    runs-on: ubuntu-latest
+    name: dclint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - run: npm install dclint
+      - run: npx dclint */docker-compose.yaml

--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -12,7 +12,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
       - run: npm install dclint
       - run: npx dclint */docker-compose.yaml

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -9,5 +9,5 @@ services:
     volumes:
       - ../data:/data
     ports:
-      - '9443:9443'
+      - '0.0.0.0:9443:9443'
     restart: unless-stopped

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -9,5 +9,5 @@ services:
     volumes:
       - ../data:/data
     ports:
-      - '0.0.0.0:9443:9443'
+      - '9443:9443'
     restart: unless-stopped


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Docker Compose linting. The workflow is designed to automatically run lint checks on Docker Compose files when there are pushes or pull requests to the repository.

New GitHub Actions workflow:

* [`.github/workflows/dclint.yml`](diffhunk://#diff-89bfe42c897a5bb96d0aee5739c9cc92fe40b1e260b836b41e4c80ccea3f6670R1-R18): Added a new workflow named "Docker Compose Lint" that runs on `ubuntu-latest`. It checks out the code, sets up Node.js, installs `dclint`, and runs `dclint` on `docker-compose.yaml` files.