### PR TITLE
Change dclint run to all PRs and only pushes to main.

### DIFF
--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -2,6 +2,7 @@ name: Docker Compose Lint
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dclint.yml` file. The change specifies that the Docker Compose Lint workflow should run on pushes to the `main` branch.

* [`.github/workflows/dclint.yml`](diffhunk://#diff-89bfe42c897a5bb96d0aee5739c9cc92fe40b1e260b836b41e4c80ccea3f6670R5): Added `branches: [ "main" ]` to the `push` event configuration.