### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -1,5 +1,8 @@
 name: Docker Compose Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hjmcnew/portainer-docker-compose/security/code-scanning/1](https://github.com/hjmcnew/portainer-docker-compose/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs linting and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
