### PR TITLE
Add .env to gitignore and harden container security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+*.env
+!.env.example
 node_modules/
 package.json
 package-lock.json

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       retries: 30
       start_period: 120s
     labels:
-      ofelia.job-exec.certbot-renew.schedule: '0 23 0 * * 1'
+      ofelia.job-exec.certbot-renew.schedule: "0 23 0 * * 1"
       ofelia.job-exec.certbot-renew.command: 'certbot renew --deploy-hook "touch /etc/letsencrypt/.renewed"'
 
   ofelia:
@@ -59,15 +59,15 @@ services:
     cap_drop:
       - ALL
     labels:
-      ofelia.job-run.restart-portainer.schedule: '0 28 0 * * 1'
-      ofelia.job-run.restart-portainer.image: 'docker:cli'
+      ofelia.job-run.restart-portainer.schedule: "0 28 0 * * 1"
+      ofelia.job-run.restart-portainer.image: "docker:cli"
       ofelia.job-run.restart-portainer.command: >-
         sh -c "docker exec certbot test -f /etc/letsencrypt/.renewed
         && docker restart portainer
         && docker exec certbot rm /etc/letsencrypt/.renewed
         || true"
-      ofelia.job-run.restart-portainer.volume: '/var/run/docker.sock:/var/run/docker.sock'
-      ofelia.job-run.restart-portainer.delete: 'true'
+      ofelia.job-run.restart-portainer.volume: "/var/run/docker.sock:/var/run/docker.sock"
+      ofelia.job-run.restart-portainer.delete: "true"
 
   portainer:
     image: portainer/portainer-ee:2.39.1-alpine
@@ -79,7 +79,7 @@ services:
       - ../data:/data
       - letsencrypt:/certs:ro
     ports:
-      - '0.0.0.0:9443:9443'
+      - "0.0.0.0:9443:9443"
     command:
       - --tlscert
       - /certs/live/${DOMAIN}/fullchain.pem

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -28,6 +28,10 @@ services:
         sleep infinity
     entrypoint: /bin/sh
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     healthcheck:
       test:
         - CMD-SHELL
@@ -50,6 +54,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     command: daemon --docker
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     labels:
       ofelia.job-run.restart-portainer.schedule: '0 28 0 * * 1'
       ofelia.job-run.restart-portainer.image: 'docker:cli'


### PR DESCRIPTION
## Summary
- Add `.env` and `*.env` to `.gitignore` (with `!.env.example` exclusion) to prevent accidental credential commits
- Add `cap_drop: [ALL]` and `no-new-privileges:true` to certbot and ofelia containers to minimize privilege

## Notes
- certbot (DNS-01 via Route53) only makes outbound HTTPS requests and writes to `/etc/letsencrypt` — no Linux capabilities required
- ofelia communicates with Docker via the mounted Unix socket — no Linux capabilities required

## Test plan
- [ ] Confirm `.env` files are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)