### PR TITLE
Remove Ofelia from portainer stack

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -44,31 +44,6 @@ services:
       ofelia.job-exec.certbot-renew.schedule: "0 23 0 * * 1"
       ofelia.job-exec.certbot-renew.command: 'certbot renew --deploy-hook "touch /etc/letsencrypt/.renewed"'
 
-  ofelia:
-    image: mcuadros/ofelia:0.3.21
-    container_name: ofelia
-    depends_on:
-      certbot:
-        condition: service_healthy
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    command: daemon --docker
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    labels:
-      ofelia.job-run.restart-portainer.schedule: "0 28 0 * * 1"
-      ofelia.job-run.restart-portainer.image: "docker:cli"
-      ofelia.job-run.restart-portainer.command: >-
-        sh -c "docker exec certbot test -f /etc/letsencrypt/.renewed
-        && docker restart portainer
-        && docker exec certbot rm /etc/letsencrypt/.renewed
-        || true"
-      ofelia.job-run.restart-portainer.volume: "/var/run/docker.sock:/var/run/docker.sock"
-      ofelia.job-run.restart-portainer.delete: "true"
-
   portainer:
     image: portainer/portainer-ee:2.39.1-alpine
     container_name: portainer


### PR DESCRIPTION
## Summary
- Removes the Ofelia service from this compose file
- Ofelia is moving to `hjmcnew/portainer` repo (see hjmcnew/portainer#190)
- Certbot renewal labels stay on the certbot container — the new Ofelia will discover them via `docker.sock`

## Deploy instructions
**Deploy this together with hjmcnew/portainer#190.** On your server:

1. Stop the old Ofelia: `cd portainer-docker-compose/portainer && docker compose stop ofelia && docker compose rm -f ofelia`
2. Deploy the new Ofelia from portainer repo: `cd portainer/ofelia && docker compose up -d`
3. Re-deploy this stack (without Ofelia): `cd portainer-docker-compose/portainer && docker compose up -d`
4. Verify Ofelia sees the certbot job: `docker logs ofelia`

## Test plan
- [ ] Verify certbot container still runs with its Ofelia labels
- [ ] Verify new Ofelia (from portainer repo) picks up certbot-renew job
- [ ] Verify restart-portainer job is scheduled on the new Ofelia

🤖 Generated with [Claude Code](https://claude.com/claude-code)