### PR TITLE
Upload KICS SARIF to GitHub code scanning

### DIFF
--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout
-      pull-requests: write # kics action posts PR comments (enable_comments: true)
+      security-events: write # upload SARIF to code scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,13 +30,13 @@ jobs:
       - name: run kics Scan
         uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           path: "."
           ignore_on_exit: results
-          enable_comments: true
           output_path: results-dir
           output_formats: "json,sarif"
-      - name: Show results
-        run: |
-          cat results-dir/results.sarif
-          cat results-dir/results.json
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results-dir/results.sarif
+          category: kics


### PR DESCRIPTION
## Summary
- Add `github/codeql-action/upload-sarif` step so KICS findings show up in Security → Code scanning and as inline PR annotations alongside CodeQL.
- Drop the `enable_comments` PR comment, the `cat`-results log dump, and the `pull-requests: write` permission; swap in `security-events: write`.
- Categorize the upload as `kics` so it tracks separately from CodeQL in the analyses list.

## Test plan
- [ ] CI run on this PR completes green.
- [ ] `gh api repos/hjmcnew/portainer-docker-compose/code-scanning/analyses | jq '[.[] | .tool.name] | unique'` includes `KICS` after the run.
- [ ] Security → Code scanning lists KICS-categorized alerts.
- [ ] KICS findings render as Files-changed annotations on this PR (not as a bot comment).
- [ ] zizmor stays green on the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)