### PR TITLE
Clean up KICS code-scanning findings

### DIFF
--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -22,10 +22,11 @@ services:
       test:
         - CMD
         - wget
-        - -q
+        - --no-verbose
+        - --tries=1
         - --no-check-certificate
         - --spider
-        - https://localhost:9001/
+        - https://localhost:9001/ping
       interval: 30s
       timeout: 5s
       retries: 3

--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -5,8 +5,28 @@ services:
     image: docker.io/portainer/agent:2.39.1-alpine
     container_name: portainer-agent
     volumes:
+      # Agent manages the host Docker daemon; socket mount is required.
+      # kics-scan ignore-line
       - /var/run/docker.sock:/var/run/docker.sock
+      # Agent needs host volumes dir to inspect/back-up volumes from the UI.
+      # kics-scan ignore-line
       - /var/lib/docker/volumes:/var/lib/docker/volumes
     ports:
       - '0.0.0.0:9001:9001'
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - -q
+        - --no-check-certificate
+        - --spider
+        - https://localhost:9001/
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       # kics-scan ignore-line
       - /var/lib/docker/volumes:/var/lib/docker/volumes
     ports:
-      - '0.0.0.0:9001:9001'
+      - "0.0.0.0:9001:9001"
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -44,7 +44,8 @@ services:
       start_period: 120s
     labels:
       ofelia.job-exec.certbot-renew.schedule: "0 23 0 * * 1"
-      ofelia.job-exec.certbot-renew.command: 'certbot renew --deploy-hook "touch /etc/letsencrypt/.renewed"'
+      ofelia.job-exec.certbot-renew.command: >-
+        certbot renew --deploy-hook "touch /etc/letsencrypt/.renewed"
 
   portainer:
     image: portainer/portainer-ee:2.39.1-alpine

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     image: certbot/dns-route53:v5.5.0
     container_name: certbot
     volumes:
+      # Cert handoff: certbot writes, portainer reads. Shared by design.
+      # kics-scan ignore-line
       - letsencrypt:/etc/letsencrypt
     environment:
       - DOMAIN=${DOMAIN}
@@ -52,6 +54,8 @@ services:
         condition: service_healthy
     volumes:
       - ../data:/data
+      # Cert handoff: certbot writes, portainer reads. Shared by design.
+      # kics-scan ignore-line
       - letsencrypt:/certs:ro
     ports:
       - "0.0.0.0:9443:9443"
@@ -61,6 +65,22 @@ services:
       - --tlskey
       - /certs/live/${DOMAIN}/privkey.pem
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - -q
+        - --no-check-certificate
+        - --spider
+        - https://localhost:9443/
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 volumes:
   letsencrypt:


### PR DESCRIPTION
## Summary

Drives the GitHub code-scanning dashboard from 11 open KICS alerts to 0 by hardening the two service definitions that can be hardened, and suppressing the architectural findings inline with rationale comments.

- **`portainer` service** — added `security_opt: [no-new-privileges:true]`, `cap_drop: [ALL]`, and a wget-based healthcheck on `:9443`. Server doesn't mount the docker socket (the agent does), so dropping all capabilities is safe.
- **`portainer-agent` service** — same hardening triple, healthcheck on `:9001`. Agent reaches docker via the unix socket and binds an unprivileged port, so `cap_drop: ALL` is fine.
- **Architectural findings (5)** — suppressed in source with `# kics-scan ignore-line` plus a one-line rationale:
  - `portainer-agent` host docker socket mount (alerts #2, #4)
  - `portainer-agent` `/var/lib/docker/volumes` mount (alert #3)
  - `letsencrypt` shared volume between certbot (writer) and portainer (reader) (alerts #11, #12)

Mirrors the pattern already used on the `certbot` service.

## Test plan

- [x] dclint passes (exit 0; same key-order warnings the existing certbot service already triggers)
- [ ] KICS workflow run on this PR reports clean
- [ ] After merge to `main`, all 11 alerts auto-close in Security → Code scanning
- [ ] Smoke-test the stack locally before merging — `cap_drop: ALL` and the new healthcheck are the riskiest changes:
  ```bash
  cd portainer && docker compose up -d
  docker compose ps                 # both services should reach (healthy)
  curl -k https://localhost:9443/   # 200/302 from portainer
  docker compose logs portainer portainer-agent | grep -iE 'permission|denied|cap'
  docker compose down
  ```
  If either service won't start or the healthcheck never goes green, capabilities are the first place to look — relax `cap_drop: ALL` to a targeted list.

https://claude.ai/code/session_014TyyfcaCfVFJA3LkbDhpRN

---
_Generated by [Claude Code](https://claude.ai/code/session_014TyyfcaCfVFJA3LkbDhpRN)_