### PR TITLE
Switch KICS suppression to file-start disable directive

### DIFF
--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -1,15 +1,17 @@
 ---
+# kics-scan disable=1c1325ff-831d-43a1-973e-839ae57dfcc0,d6355c88-1e8d-49e9-b2f2-f8a1ca12c75b
+# Disabled queries (and the reason they're accepted):
+#   1c1325ff... Volume Has Sensitive Host Directory
+#   d6355c88... Docker Socket Mounted In Container
+# Portainer agent's job is to manage the host Docker daemon. Mounting the docker
+# socket and /var/lib/docker/volumes is required for normal operation.
 name: portainer-agent
 services:
   portainer-agent:
     image: docker.io/portainer/agent:2.39.1-alpine
     container_name: portainer-agent
     volumes:
-      # Agent manages the host Docker daemon; socket mount is required.
-      # kics-scan ignore-line
       - /var/run/docker.sock:/var/run/docker.sock
-      # Agent needs host volumes dir to inspect/back-up volumes from the UI.
-      # kics-scan ignore-line
       - /var/lib/docker/volumes:/var/lib/docker/volumes
     ports:
       - "0.0.0.0:9001:9001"

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -1,4 +1,9 @@
 ---
+# kics-scan disable=8c978947-0ff6-485c-b0c2-0bfca6026466
+# Disabled query (and the reason it's accepted):
+#   8c978947... Shared Volumes Between Containers
+# The `letsencrypt` named volume is the cert handoff between certbot (writer)
+# and portainer (reader). Sharing is the entire design.
 name: portainer
 include:
   - ../portainer-agent/docker-compose.yaml
@@ -7,8 +12,6 @@ services:
     image: certbot/dns-route53:v5.5.0
     container_name: certbot
     volumes:
-      # Cert handoff: certbot writes, portainer reads. Shared by design.
-      # kics-scan ignore-line
       - letsencrypt:/etc/letsencrypt
     environment:
       - DOMAIN=${DOMAIN}
@@ -55,8 +58,6 @@ services:
         condition: service_healthy
     volumes:
       - ../data:/data
-      # Cert handoff: certbot writes, portainer reads. Shared by design.
-      # kics-scan ignore-line
       - letsencrypt:/certs:ro
     ports:
       - "0.0.0.0:9443:9443"


### PR DESCRIPTION
## Summary

Replaces the inline `# kics-scan ignore-line` comments added in #65 with the docs-blessed `# kics-scan disable=<query_id>` file-start directive. The inline form doesn't actually suppress findings in YAML compose files — that's why the 5 architectural alerts (#13–17) re-fired on the post-merge scan of `01de586`.

## Why

KICS has well-documented bugs around inline ignore directives in YAML:
- [Checkmarx/kics#6917](https://github.com/Checkmarx/kics/issues/6917) — `ignore-block` in YAML applies to the parent block instead of the targeted child item.
- [Checkmarx/kics#5177](https://github.com/Checkmarx/kics/issues/5177) — `ignore-line` doesn't work in YAML at all.
- [Checkmarx/kics#7054](https://github.com/Checkmarx/kics/issues/7054) — same symptom in nested K8s manifests.
- [Checkmarx/kics#6458](https://github.com/Checkmarx/kics/issues/6458) — file-start `kics-scan` directives must be the first valid line.

Per the [KICS docs](https://docs.kics.io/latest/running-kics/), the file-start `disable=<id>` syntax is reliable. Both compose files are tightly scoped to a single concern, so file-level disable is the right granularity.

## Changes

- `portainer-agent/docker-compose.yaml` — disable `Volume Has Sensitive Host Directory` and `Docker Socket Mounted In Container`. Both are inherent to the agent's job of managing the host docker daemon.
- `portainer/docker-compose.yaml` — disable `Shared Volumes Between Containers`. The `letsencrypt` named volume is the certbot↔portainer cert handoff and shared by design.
- Removed the now-dead inline `# kics-scan ignore-line` markers; rationale moves to a single block at the top of each file alongside the directive that actually does the work.

## Verification

Ran KICS locally against `checkmarx/kics:v2.1.20` — the engine pinned by `kics-github-action@v2.1.20` (verified via the action's `Dockerfile`):

```bash
docker run --rm -t -v "$PWD:/path" checkmarx/kics:v2.1.20 \
  scan -p /path -o /path/kics-out --report-formats sarif,json --no-progress --ci
```

Result: 6 files scanned, 0 findings (down from 5 on `main`).

## Test plan

- [x] Local KICS run with the same engine version as CI returns 0 findings.
- [ ] CI KICS workflow on this PR passes with a clean SARIF.
- [ ] After merge, alerts #13, #14, #15, #16, #17 auto-close on the next push to `main`. Verify with `gh api repos/hjmcnew/portainer-docker-compose/code-scanning/alerts?state=open | jq length` → expect 0.
- [x] No runtime smoke test needed — comment-only change, no compose semantics altered.