### PR TITLE
Use 127.0.0.1 in ofelia healthcheck to match its v4-only bind

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -75,7 +75,10 @@ services:
         - --no-verbose
         - --tries=1
         - --spider
-        - http://localhost:8081/
+        # 127.0.0.1 (not localhost) — busybox wget resolves localhost to
+        # [::1] first, but ofelia binds OFELIA_WEB_ADDRESS=127.0.0.1:8081
+        # (v4 only), so an IPv6 probe gets connection refused.
+        - http://127.0.0.1:8081/
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Summary
- Ofelia is marked unhealthy with `Connecting to localhost:8081 ([::1]:8081) wget: can't connect to remote host: Connection refused` even though its log says `Web UI ready at http://127.0.0.1:8081`
- Busybox `wget` in the alpine base resolves `localhost` to `[::1]` first; ofelia's `OFELIA_WEB_ADDRESS=127.0.0.1:8081` is IPv4-only, so the IPv6 probe fails with no fallback
- Change the healthcheck probe URL from `http://localhost:8081/` to `http://127.0.0.1:8081/` to match the bind. `OFELIA_WEB_ADDRESS` stays single-stack v4

## Test plan
- [x] `prettier --check portainer/docker-compose.yaml` passes (verified locally)
- [x] `dclint portainer/docker-compose.yaml` clean (verified locally)
- [x] `docker compose -f portainer/docker-compose.yaml config --quiet` validates (verified locally)
- [x] KICS scan: 0 findings (verified locally)
- [ ] After deploy: `docker inspect ofelia --format '{{.State.Health.Status}}'` reports `healthy` within ~30s
- [ ] CI: KICS, super-linter, dclint, zizmor all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)