### PR TITLE
Add --docker-events to ofelia daemon for cross-stack label discovery

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -66,7 +66,11 @@ services:
     environment:
       OFELIA_ENABLE_WEB: 'true'
       OFELIA_WEB_ADDRESS: 127.0.0.1:8081
-    command: daemon
+    # --docker-events makes ofelia react to container start/stop events from
+    # the docker daemon, which (empirically) is required to pick up
+    # ofelia.job-* labels on containers in sibling compose stacks (e.g. the
+    # forgejo stack's renovate job). Default polling alone wasn't catching it.
+    command: daemon --docker-events
     restart: unless-stopped
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
- Ofelia is not picking up `ofelia.job-run.renovate.*` labels on a forgejo container in a sibling compose stack
- The netresearch fork's README claims label discovery is on by default, but empirically `--docker-events` is needed for cross-stack containers
- Add `daemon --docker-events` so ofelia reacts to docker daemon start/stop events for any container, not just whatever its current poll-set sees

## Test plan
- [x] `prettier --check` passes (verified locally)
- [x] `dclint` clean (verified locally)
- [x] `docker compose ... config --quiet` validates (verified locally)
- [x] KICS scan: 0 findings (verified locally)
- [ ] After deploy: `docker compose -p portainer up -d ofelia` recreates with the new flag
- [ ] `docker logs ofelia 2>&1 | rg -i 'renovate|forgejo'` shows the renovate job being registered
- [ ] Renovate runs on its scheduled cadence
- [ ] CI: KICS, super-linter, dclint, zizmor all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)