### PR TITLE
Revert "Add --docker-events to ofelia daemon for cross-stack label discovery (#72)"

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -66,11 +66,7 @@ services:
     environment:
       OFELIA_ENABLE_WEB: 'true'
       OFELIA_WEB_ADDRESS: 127.0.0.1:8081
-    # --docker-events makes ofelia react to container start/stop events from
-    # the docker daemon, which (empirically) is required to pick up
-    # ofelia.job-* labels on containers in sibling compose stacks (e.g. the
-    # forgejo stack's renovate job). Default polling alone wasn't catching it.
-    command: daemon --docker-events
+    command: daemon
     restart: unless-stopped
     healthcheck:
       test:


### PR DESCRIPTION
Reverts #72.

That PR was merged to `main` without my approval, so this restores `portainer/docker-compose.yaml` to its pre-#72 state (`command: daemon`, no `--docker-events` flag, no surrounding comment block).

If the underlying behavior change is wanted later, it should be re-proposed as a fresh PR.