### PR TITLE
Add ofelia.enabled=true to certbot for job discovery

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       retries: 30
       start_period: 120s
     labels:
+      ofelia.enabled: 'true'
       ofelia.job-exec.certbot-renew.schedule: '0 23 0 * * 1'
       ofelia.job-exec.certbot-renew.command: >-
         certbot renew --deploy-hook "touch /etc/letsencrypt/.renewed"


### PR DESCRIPTION
## Summary
- The `certbot-renew` ofelia job has never been picked up. Root cause: netresearch/ofelia v0.23.1 hardcodes a Docker label filter `ofelia.enabled=true` on both its container list query (`cli/docker_config_handler.go` `GetDockerContainers`) and its docker events subscription. Containers with only `ofelia.job-exec.*` labels are silently filtered out.
- Adds the missing `ofelia.enabled: 'true'` label to the `certbot` service. Quoted as a string to match the netresearch/ofelia README/docs examples.
- This also explains why PR #72 (`--docker-events`) didn't help — the same enabled-label filter is applied to events. The proper fix is the label, not the flag.

## Out of scope
- The `ofelia` service itself has `ofelia.job-run.restart-portainer.*` labels and the same missing-`enabled` gap; deliberately not changed here.
- Re-adding `--docker-events` for the cross-stack forgejo/renovate label — handle separately.

## Test plan
- [ ] CI (dclint, KICS, yamllint baseline) passes.
- [ ] After deploy, `docker logs ofelia` shows the `certbot-renew` job registered at startup (no `ErrNoContainerWithOfeliaEnabled`).
- [ ] `curl -s http://127.0.0.1:8081/` lists `certbot-renew` in ofelia's web UI.
- [ ] At the next Monday 00:23 UTC tick (or via an out-of-band trigger from the web UI) the job runs and on a real renewal `/etc/letsencrypt/.renewed` is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)