### PR TITLE
Update README and .gitignore to reflect current repo state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .env
 *.env
 !.env.example
+
+# Portainer runtime state (bind-mounted via ../data:/data)
+data/
+
+# dclint installs into the repo root via `npm install dclint` in CI
 node_modules/
 package.json
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker Compose configurations for deploying [Portainer EE](https://www.portainer
 
 ## Repository Structure
 
-```
+```text
 portainer/             # Portainer EE server with SSL and cert automation
   docker-compose.yaml
   .env.example         # Template for required environment variables
@@ -38,32 +38,32 @@ A standalone Portainer Agent deployment on port `9001`, suitable for adding remo
 
 1. Clone the repository:
 
-    ```sh
-    git clone https://github.com/hjmcnew/portainer-docker-compose.git
-    cd portainer-docker-compose
-    ```
+   ```sh
+   git clone https://github.com/hjmcnew/portainer-docker-compose.git
+   cd portainer-docker-compose
+   ```
 
 2. Create a `.env` file in the `portainer/` directory with your configuration. A template is provided at `portainer/.env.example`:
 
-    ```sh
-    cp portainer/.env.example portainer/.env
-    ```
+   ```sh
+   cp portainer/.env.example portainer/.env
+   ```
 
-    ```env
-    DOMAIN=portainer.example.com
-    EMAIL=you@example.com
-    AWS_ACCESS_KEY_ID=your-key-id
-    AWS_SECRET_ACCESS_KEY=your-secret-key
-    ```
+   ```env
+   DOMAIN=portainer.example.com
+   EMAIL=you@example.com
+   AWS_ACCESS_KEY_ID=your-key-id
+   AWS_SECRET_ACCESS_KEY=your-secret-key
+   ```
 
 3. Start the stack:
 
-    ```sh
-    cd portainer
-    docker compose up -d
-    ```
+   ```sh
+   cd portainer
+   docker compose up -d
+   ```
 
-    Certbot will obtain a certificate on first run. The healthcheck waits for the cert to be issued before Portainer starts.
+   Certbot will obtain a certificate on first run. The healthcheck waits for the cert to be issued before Portainer starts.
 
 4. Access Portainer at `https://your-domain:9443`.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Docker Compose configurations for deploying [Portainer EE](https://www.portainer
 ```
 portainer/             # Portainer EE server with SSL and cert automation
   docker-compose.yaml
+  .env.example         # Template for required environment variables
 portainer-agent/       # Standalone Portainer Agent for remote endpoints
   docker-compose.yaml
 ```
@@ -42,7 +43,11 @@ A standalone Portainer Agent deployment on port `9001`, suitable for adding remo
     cd portainer-docker-compose
     ```
 
-2. Create a `.env` file in the `portainer/` directory with your configuration:
+2. Create a `.env` file in the `portainer/` directory with your configuration. A template is provided at `portainer/.env.example`:
+
+    ```sh
+    cp portainer/.env.example portainer/.env
+    ```
 
     ```env
     DOMAIN=portainer.example.com
@@ -82,8 +87,13 @@ No manual intervention is required.
 
 ## CI
 
-- **Docker Compose Lint** — validates compose files on push and PRs using [dclint](https://github.com/zavoloklom/docker-compose-linter)
-- **Dependabot** — monitors for Docker image and GitHub Actions updates weekly (major version bumps are ignored for Docker images)
+GitHub Actions workflows run on push and pull requests to `main`:
+
+- **Docker Compose Lint** — validates compose files using [dclint](https://github.com/zavoloklom/docker-compose-linter)
+- **KICS** — scans infrastructure-as-code for security issues and uploads SARIF results to GitHub code scanning
+- **Super-Linter** — runs [super-linter](https://github.com/super-linter/super-linter) across changed files
+- **zizmor** — audits GitHub Actions workflows with [zizmor](https://github.com/zizmorcore/zizmor)
+- **Renovate** — monitors Docker image and GitHub Actions updates weekly (major version bumps are disabled); see `renovate.json`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Bring `README.md` and `.gitignore` back in sync with what the repo actually contains today.

### README

- **CI section**: replace the stale `Dependabot` bullet with `Renovate` (the repo switched to Renovate in #60 / added `renovate.json` in #59), and add the `KICS`, `Super-Linter`, and `zizmor` workflows that already exist in `.github/workflows/` but were never documented.
- **Getting Started**: point users at `portainer/.env.example` (which exists in the repo) as the env template, with a `cp` command, instead of asking them to write a `.env` from scratch.
- **Repository Structure**: list `.env.example` under `portainer/`.

### .gitignore

- Ignore `data/`. `portainer/docker-compose.yaml` mounts `../data:/data`, so a `data/` directory is created at the repo root on first run and would otherwise show up as untracked Portainer state.
- Annotate the existing `node_modules/`, `package.json`, `package-lock.json` entries — they're there because the dclint workflow runs `npm install dclint` from the repo root.

## Test plan

- [x] `git diff` reviewed — only README and .gitignore touched
- [ ] dclint / super-linter / KICS / zizmor pass on this branch in CI
- [ ] README renders correctly on GitHub

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiCozzMNwjYDySJMU1cz2y)_