### PR TITLE
Fix agent/portainer healthcheck PID leak (wget https -> nc TCP probe)

### DIFF
--- a/portainer-agent/docker-compose.yaml
+++ b/portainer-agent/docker-compose.yaml
@@ -17,14 +17,19 @@ services:
       - '0.0.0.0:9001:9001'
     restart: unless-stopped
     healthcheck:
+      # TCP liveness only (not an HTTPS /ping check): busybox wget's https://
+      # probe forks a second process (ssl_client) for the TLS handshake, and
+      # that forked process leaks ~1 thread per probe in the agent's Go TLS
+      # server. Over days this exhausts the host's pids ceiling, after which
+      # nothing in the container can fork -- including the probe's own wget
+      # -- pinning the container "unhealthy" forever. 127.0.0.1 (not
+      # localhost) avoids an IPv6 probe against the agent's IPv4 bind.
       test:
         - CMD
-        - wget
-        - --no-verbose
-        - --tries=1
-        - --no-check-certificate
-        - --spider
-        - https://localhost:9001/ping
+        - nc
+        - -z
+        - 127.0.0.1
+        - '9001'
       interval: 30s
       timeout: 5s
       retries: 3

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -117,13 +117,19 @@ services:
       - /certs/live/${DOMAIN}/privkey.pem
     restart: unless-stopped
     healthcheck:
+      # TCP liveness only (not an HTTPS check): busybox wget's https:// probe
+      # forks a second process (ssl_client) for the TLS handshake, and that
+      # forked process leaks ~1 thread per probe in portainer's Go TLS
+      # server. Over days this exhausts the host's pids ceiling, after which
+      # nothing in the container can fork -- including the probe's own wget
+      # -- pinning the container "unhealthy" forever. 127.0.0.1 (not
+      # localhost) avoids an IPv6 probe against portainer's IPv4 bind.
       test:
         - CMD
-        - wget
-        - -q
-        - --no-check-certificate
-        - --spider
-        - https://localhost:9443/
+        - nc
+        - -z
+        - 127.0.0.1
+        - '9443'
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Several agent hosts (argon, klippy, hive) showed `unhealthy` with failing streaks in the tens of thousands and `wget: fork: Resource temporarily unavailable`.
- Root cause: the `wget --no-check-certificate https://…` healthcheck probe forks a second process (`ssl_client`) for the TLS handshake, and that leak accumulates ~1 thread per probe in the target Go TLS server. At a 30s interval that's ~2,880 threads/day, eventually exhausting the host's pids ceiling — after which nothing in the container can `fork()`, including the probe's own `wget`, so it's pinned unhealthy forever.
- Confirmed via the live fleet (`portainerctl`): hosts with **no** healthcheck ran 9–19 threads over months; hosts with this probe climbed steadily regardless of Docker version, host arch, or agent version — those were red herrings. The Portainer **server** (`:9443`) has the identical probe and leaks the same way, just with more headroom (125GB host).
- Fix: replace both HTTPS `wget --spider` probes with a single-process TCP liveness check (busybox `nc -z 127.0.0.1 <port>`), which never touches TLS and doesn't fork, so it can't leak. `127.0.0.1` (not `localhost`) also avoids the IPv6-vs-IPv4-bind mismatch already fixed for ofelia in #70.
- No official healthcheck ships in either image by design (open, unaddressed upstream requests: portainer/agent#731, portainer/portainer#11492, portainer/agent#433), and image inspection confirms the only non-leaking network tool available is busybox `nc`.

## Test plan
- [x] `docker compose config` validates both files
- [x] `npx dclint@3.1.0 --max-warnings=0` (matches CI) passes clean
- [x] No new `yamllint`-length violations introduced
- [x] Locally ran `portainer/agent:2.43.0-alpine`, confirmed `nc -z 127.0.0.1 9001` exits `0` while listening and `1` against a closed port
- [ ] After merge: redeploy affected hosts, confirm `State.Health.Status` recovers to `healthy` and `pids_stats.current` stays flat over 24–48h (was climbing ~2,880/day before)